### PR TITLE
Bump netty.version from 4.1.53.Final to 4.1.59.Final in /broker

### DIFF
--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <bintray.package>io.moquette.moquette-broker</bintray.package>
-        <netty.version>4.1.53.Final</netty.version>
+        <netty.version>4.1.59.Final</netty.version>
         <netty.tcnative.version>2.0.34.Final</netty.tcnative.version>
         <paho.version>1.2.5</paho.version>
         <h2.version>1.4.199</h2.version>


### PR DESCRIPTION
Bumps `netty.version` from 4.1.53.Final to 4.1.59.Final.

Updates `netty-common` from 4.1.53.Final to 4.1.59.Final
- [Release notes](https://github.com/netty/netty/releases)
- [Commits](https://github.com/netty/netty/compare/netty-4.1.53.Final...netty-4.1.59.Final)

Updates `netty-buffer` from 4.1.53.Final to 4.1.59.Final
- [Release notes](https://github.com/netty/netty/releases)
- [Commits](https://github.com/netty/netty/compare/netty-4.1.53.Final...netty-4.1.59.Final)

Updates `netty-transport` from 4.1.53.Final to 4.1.59.Final
- [Release notes](https://github.com/netty/netty/releases)
- [Commits](https://github.com/netty/netty/compare/netty-4.1.53.Final...netty-4.1.59.Final)

Updates `netty-handler` from 4.1.53.Final to 4.1.59.Final
- [Release notes](https://github.com/netty/netty/releases)
- [Commits](https://github.com/netty/netty/compare/netty-4.1.53.Final...netty-4.1.59.Final)

Updates `netty-codec` from 4.1.53.Final to 4.1.59.Final
- [Release notes](https://github.com/netty/netty/releases)
- [Commits](https://github.com/netty/netty/compare/netty-4.1.53.Final...netty-4.1.59.Final)

Updates `netty-codec-http` from 4.1.53.Final to 4.1.59.Final
- [Release notes](https://github.com/netty/netty/releases)
- [Commits](https://github.com/netty/netty/compare/netty-4.1.53.Final...netty-4.1.59.Final)

Updates `netty-codec-mqtt` from 4.1.53.Final to 4.1.59.Final
- [Release notes](https://github.com/netty/netty/releases)
- [Commits](https://github.com/netty/netty/compare/netty-4.1.53.Final...netty-4.1.59.Final)

Updates `netty-transport-native-epoll` from 4.1.53.Final to 4.1.59.Final
- [Release notes](https://github.com/netty/netty/releases)
- [Commits](https://github.com/netty/netty/compare/netty-4.1.53.Final...netty-4.1.59.Final)

Signed-off-by: dependabot[bot] <support@github.com>